### PR TITLE
Add beforeSend props to ErrorBoundary

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -95,6 +95,11 @@ class BadButton extends React.Component {
 
 const ErrorBoundary = bugsnagClient.use(bugsnag__react())
 
+// You can provide a `beforeSend` function to the ErrorBoundary which will be passed to the Bugsnag.notify call
+const beforeSend = (report) => {
+  report.severity = 'info'
+}
+
 // You can provide a FallbackComponent to the ErrorBoundary which will be rendered if an error is encountered
 // It will be passed the `error` and `info` from the `componentDidCatch` method as props
 const FallbackComponent = ({_error, info}) => (
@@ -102,7 +107,7 @@ const FallbackComponent = ({_error, info}) => (
 )
 
 ReactDOM.render(
-  <ErrorBoundary FallbackComponent={FallbackComponent}>
+  <ErrorBoundary FallbackComponent={FallbackComponent} beforeSend={beforeSend}>
     <BadButton />
   </ErrorBoundary>,
   document.getElementById('root')

--- a/example/app.js
+++ b/example/app.js
@@ -95,8 +95,14 @@ class BadButton extends React.Component {
 
 const ErrorBoundary = bugsnagClient.use(bugsnag__react())
 
+// You can provide a FallbackComponent to the ErrorBoundary which will be rendered if an error is encountered
+// It will be passed the `error` and `info` from the `componentDidCatch` method as props
+const FallbackComponent = ({error, info}) => (
+  <div>An error has occurred</div>
+)
+
 ReactDOM.render(
-  <ErrorBoundary>
+  <ErrorBoundary FallbackComponent={FallbackComponent}>
     <BadButton />
   </ErrorBoundary>,
   document.getElementById('root')

--- a/example/app.js
+++ b/example/app.js
@@ -97,7 +97,7 @@ const ErrorBoundary = bugsnagClient.use(bugsnag__react())
 
 // You can provide a FallbackComponent to the ErrorBoundary which will be rendered if an error is encountered
 // It will be passed the `error` and `info` from the `componentDidCatch` method as props
-const FallbackComponent = ({error, info}) => (
+const FallbackComponent = ({_error, info}) => (
   <div>An error has occurred</div>
 )
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ module.exports = (React = window.React) => {
           const report = new BugsnagReport(error.name, error.message, BugsnagReport.getStacktrace(error), handledState)
           if (info && info.componentStack) info.componentStack = formatComponentStack(info.componentStack)
           report.updateMetaData('react', info)
-          client.notify(report, { beforeSend: beforeSend })
+          client.notify(report, { beforeSend })
           this.setState({ error, info })
         }
         render () {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,12 @@ module.exports = (React = window.React) => {
   return {
     init: (client) => {
       class ErrorBoundary extends React.Component {
+        constructor (props) {
+          super(props)
+          this.state = {
+            error: null
+          }
+        }
         componentDidCatch (error, info) {
           const BugsnagReport = client.BugsnagReport
           const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledException' } }
@@ -11,8 +17,12 @@ module.exports = (React = window.React) => {
           if (info && info.componentStack) info.componentStack = formatComponentStack(info.componentStack)
           report.updateMetaData('react', info)
           client.notify(report)
+          this.setState({error: error})
         }
         render () {
+          if (this.state.error) {
+            return null
+          }
           return this.props.children
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,17 @@ module.exports = (React = window.React) => {
           if (info && info.componentStack) info.componentStack = formatComponentStack(info.componentStack)
           report.updateMetaData('react', info)
           client.notify(report)
-          this.setState({error: error})
+          this.setState({
+            error: error
+          })
         }
         render () {
-          if (this.state.error) {
+          const {error} = this.state
+          if (error) {
+            const {FallbackComponent} = this.props
+            if (FallbackComponent) {
+              return React.createElement(FallbackComponent, null)
+            }
             return null
           }
           return this.props.children

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ module.exports = (React = window.React) => {
         constructor (props) {
           super(props)
           this.state = {
-            error: null
+            error: null,
+            info: null
           }
         }
         componentDidCatch (error, info) {
@@ -17,16 +18,14 @@ module.exports = (React = window.React) => {
           if (info && info.componentStack) info.componentStack = formatComponentStack(info.componentStack)
           report.updateMetaData('react', info)
           client.notify(report)
-          this.setState({
-            error: error
-          })
+          this.setState({error, info})
         }
         render () {
           const {error} = this.state
           if (error) {
             const {FallbackComponent} = this.props
             if (FallbackComponent) {
-              return React.createElement(FallbackComponent, null)
+              return React.createElement(FallbackComponent, this.state)
             }
             return null
           }

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,13 @@ module.exports = (React = window.React) => {
           }
         }
         componentDidCatch (error, info) {
+          const {beforeSend} = this.props
           const BugsnagReport = client.BugsnagReport
           const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledException' } }
           const report = new BugsnagReport(error.name, error.message, BugsnagReport.getStacktrace(error), handledState)
           if (info && info.componentStack) info.componentStack = formatComponentStack(info.componentStack)
           report.updateMetaData('react', info)
-          client.notify(report)
+          client.notify(report, {beforeSend: beforeSend})
           this.setState({error, info})
         }
         render () {

--- a/src/test/__snapshots__/index.test.js.snap
+++ b/src/test/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<p>
-  test
-</p>
-`;
+exports[`does not render FallbackComponent when no error 1`] = `"test"`;
+
+exports[`renders FallbackComponent on error 1`] = `"fallback"`;
+
+exports[`renders correctly 1`] = `"test"`;

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -71,3 +71,15 @@ it('renders FallbackComponent on error', () => {
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+it('passes the props to the FallbackComponent', () => {
+  renderer
+    .create(<ErrorBoundary FallbackComponent={FallbackComponent}><BadComponent /></ErrorBoundary>)
+  expect(FallbackComponent).toBeCalledWith(
+    expect.objectContaining({
+      error: expect.anything(),
+      info: expect.anything()
+    }),
+    expect.anything()
+  )
+})

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -29,16 +29,20 @@ test('formatComponentStack(str)', () => {
     .toBe(`in BadButton\nin ErrorBoundary`)
 })
 
-it('renders correctly', () => {
-  const tree = renderer
-    .create(<ErrorBoundary><p>test</p></ErrorBoundary>)
-    .toJSON()
-  expect(tree).toMatchSnapshot()
-})
-
 const BadComponent = () => {
   throw Error('BadComponent')
 }
+
+const GoodComponent = () => ('test')
+
+const FallbackComponent = jest.fn(() => 'fallback')
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(<ErrorBoundary><GoodComponent /></ErrorBoundary>)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
 
 it('renders correctly on error', () => {
   const tree = renderer
@@ -52,4 +56,18 @@ it('calls notify on error', () => {
     .create(<ErrorBoundary><BadComponent /></ErrorBoundary>)
     .toJSON()
   expect(bugsnag.notify).toHaveBeenCalledTimes(1)
+})
+
+it('does not render FallbackComponent when no error', () => {
+  const tree = renderer
+    .create(<ErrorBoundary FallbackComponent={FallbackComponent}><GoodComponent /></ErrorBoundary>)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders FallbackComponent on error', () => {
+  const tree = renderer
+    .create(<ErrorBoundary FallbackComponent={FallbackComponent}><BadComponent /></ErrorBoundary>)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
 })

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -83,3 +83,11 @@ it('passes the props to the FallbackComponent', () => {
     expect.anything()
   )
 })
+
+it('it passes the beforeSend function to the Bugsnag notify call', () => {
+  const beforeSend = () => {}
+  renderer
+    .create(<ErrorBoundary beforeSend={(beforeSend)}><BadComponent /></ErrorBoundary>)
+    .toJSON()
+  expect(bugsnag.notify).toBeCalledWith(expect.anything(), expect.objectContaining({ beforeSend: beforeSend }))
+})

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -4,12 +4,14 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import index from '../'
 
+class BugsnagReport {
+  updateMetaData () {
+    return this
+  }
+}
+
 const bugsnag = {
-  BugsnagReport: jest.fn(() => {
-    return {
-      updateMetaData: jest.fn()
-    }
-  }),
+  BugsnagReport,
   notify: jest.fn()
 }
 
@@ -88,5 +90,8 @@ it('it passes the beforeSend function to the Bugsnag notify call', () => {
   renderer
     .create(<ErrorBoundary beforeSend={beforeSend}><BadComponent /></ErrorBoundary>)
     .toJSON()
-  expect(bugsnag.notify).toBeCalledWith(expect.anything(), expect.objectContaining({ beforeSend: beforeSend }))
+  expect(bugsnag.notify).toBeCalledWith(
+    expect.any(BugsnagReport),
+    expect.objectContaining({ beforeSend: beforeSend })
+  )
 })


### PR DESCRIPTION
Adds a prop to the `ErrorBoundary` component called `beforeSend`. 

This can be used to provide a function that will be passed to the bugsnag client when `notify` is called.

This PR can be pointed to `master` once #14  has been merged.