### PR TITLE
Resolve package generation issues

### DIFF
--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,3 +1,4 @@
 *
 */
 !.gitignore
+!.npmignore


### PR DESCRIPTION
Building the assets in the `version` step does not mean that they are included
in the package. This ensures that the assets are included in the npm package